### PR TITLE
Add immediate NSFW warning next to Fantasti.cc link

### DIFF
--- a/community-guidelines.txt
+++ b/community-guidelines.txt
@@ -65,8 +65,9 @@ What Tumblr is not for:
     You can embed anything as long as it follows the other guidelines on this
     page. But please don't use Tumblr's Upload Video feature to host any
     sexually explicit videos. We're not in the business of profiting from
-    adult-oriented videos and hosting this stuff is fucking expensive. You can
-    use services like [Fantasti.cc] to host those instead.
+    adult-oriented videos and hosting this stuff is fucking expensive. Instead,
+    you can host these on services like [Fantasti.cc]. (WARNING: the link
+    contains explicitly sexual content!)
 
   Non-Genuine Social Gesture Schemes.
 


### PR DESCRIPTION
I, in all my innocence, did not know what kind of site Fantasti.cc is and clicked the link to discover the porn videos hosted there. A lot of people might do the same and run into trouble for doing so inadvertently: people peeking at their screen, malware, company flagging or logging systems, etc.

Better to err on the side of caution and warn people right away to prevent them from clicking. Maybe the site should only be mentioned by name and not hyperlink, too.
